### PR TITLE
Pragma Fixed

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.22 <0.9.0;
+pragma solidity 0.8.9;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/contracts/MyNft.sol
+++ b/contracts/MyNft.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
 import "@openzeppelin/contracts/utils/Counters.sol";

--- a/contracts/NftMarket.sol
+++ b/contracts/NftMarket.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 


### PR DESCRIPTION
**Floating pragmas are considered a bad practice.**

It is always recommended that `pragma` should be fixed (not floating) to the version that you are intending to deploy your contracts with. 
I have fixed the pragma of the contracts to `0.8.9` as in the hardhat.config.ts solidity compiler version `0.8.9` is mentioned. 

For more information Check [this](https://www.oreilly.com/library/view/mastering-blockchain-programming/9781839218262/d1250994-b952-4d5e-9cde-1b852c18b55f.xhtml) out

Thanks,
AB Dee.